### PR TITLE
Add CSS styles for home page mockup and components

### DIFF
--- a/client/public/mockups/home.html
+++ b/client/public/mockups/home.html
@@ -63,25 +63,39 @@
           <a href="#"><img src="../icons/chevron-left.svg" /></a>
         </li>
         <li>
-          <a href="#"><p class="body-l">Monday</p></a>
+          <a href="#"
+            ><p class="body-l">Monday<span class="body-s">02/10</span></p></a
+          >
         </li>
         <li>
-          <a href="#"><p class="body-l">Tuesday</p></a>
+          <a href="#"
+            ><p class="body-l">Tuesday<span class="body-s">02/11</span></p></a
+          >
         </li>
         <li class="selected">
-          <a href="#"><p class="body-l">Wednesday</p></a>
+          <a href="#"
+            ><p class="body-l">Wednesday<span class="body-s">02/12</span></p></a
+          >
         </li>
         <li>
-          <a href="#"><p class="body-l">Thursday</p></a>
+          <a href="#"
+            ><p class="body-l">Thursday<span class="body-s">02/13</span></p></a
+          >
         </li>
         <li>
-          <a href="#"><p class="body-l">Friday</p></a>
+          <a href="#"
+            ><p class="body-l">Friday<span class="body-s">02/14</span></p></a
+          >
         </li>
         <li>
-          <a href="#"><p class="body-l">Saturday</p></a>
+          <a href="#"
+            ><p class="body-l">Saturday<span class="body-s">02/15</span></p></a
+          >
         </li>
         <li>
-          <a href="#"><p class="body-l">Sunday</p></a>
+          <a href="#"
+            ><p class="body-l">Sunday<span class="body-s">02/16</span></p></a
+          >
         </li>
         <li>
           <a href="#"><img src="../icons/chevron-right.svg" /></a>


### PR DESCRIPTION
Add CSS styles for home page mockup and components.
No functionality was changed.

Image of the mockup:
![screencapture-127-0-0-1-5500-client-public-mockups-home-html-2025-02-09-15_16_21](https://github.com/user-attachments/assets/1ba541bf-4c48-42f4-8fbe-4fd71dd93cc5)

