### PR TITLE
Update @google/generative-ai dependency to version 0.22.0

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google/generative-ai": "^0.21.0",
+        "@google/generative-ai": "^0.22.0",
         "axios": "^1.7.9",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -29,9 +29,9 @@
       "optional": true
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
-      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.22.0.tgz",
+      "integrity": "sha512-mLR3PDWCk5O/BWNyDvFDIiwKeXQmFGZ+kJFd9m73QrUPCFREttJyVbBPTW4y9CwTbaltLMDaLDfroCrRv5Bl8Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
   "author": "Google LLC",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google/generative-ai": "^0.21.0",
+    "@google/generative-ai": "^0.22.0",
     "axios": "^1.7.9",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
This pull request includes updates to the `@google/generative-ai` dependency in the `server` package. The most important changes are as follows:

Dependency updates:

* [`server/package-lock.json`](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L12-R12): Updated the version of `@google/generative-ai` from `0.21.0` to `0.22.0`, including changes to the resolved URL and integrity hash. [[1]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L12-R12) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L32-R34)
* [`server/package.json`](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L16-R16): Updated the version of `@google/generative-ai` from `0.21.0` to `0.22.0`.