### PR TITLE
SCRUM-38 Add @react-oauth/google dependency to client package

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.1",
         "page": "^1.3.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1069,6 +1070,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.1.tgz",
+      "integrity": "sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.1",
     "page": "^1.3.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
This pull request includes changes to add a new dependency to the project. Specifically, the `@react-oauth/google` package has been added to the `client` project.

Dependency additions:

* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fR13): Added `@react-oauth/google` version `^0.12.1` to the dependencies.
* [`client/package-lock.json`](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dR11): Added `@react-oauth/google` version `0.12.1` with its resolved URL, integrity hash, license, and peer dependencies. [[1]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dR11) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dR1075-R1084)