### PR TITLE
Fix firebase cloud run configuration

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -31,12 +31,16 @@ try {
 
     admin.initializeApp({
       credential: admin.credential.cert(serviceAccount),
+      projectId: "mealplangenerator-2c4bb",
     });
 
     console.log("Firebase Admin SDK initialized (local development).");
   } else {
     // Cloud Run: Use ADC (Application Default Credentials)
-    admin.initializeApp();
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+      projectId: "mealplangenerator-2c4bb",
+    });
     console.log("Firebase Admin SDK initialized using ADC (Cloud Run).");
   }
 } catch (error) {


### PR DESCRIPTION
This pull request includes changes to the Firebase Admin SDK initialization in the `server/server.js` file to specify the `projectId` for both local development and Cloud Run environments.

Initialization updates:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R34-R43): Added the `projectId` "mealplangenerator-2c4bb" to the Firebase Admin SDK initialization for both local development and Cloud Run environments.