### PR TITLE
Remove token verification from recipe API endpoints

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -79,7 +79,7 @@ app.get("/", (req, res) => {
   res.send(`Hello ${name}!`);
 });
 
-app.get("/api/recipes/:uid", verifyToken, async (req, res) => {
+app.get("/api/recipes/:uid", async (req, res) => {
   if (!req.params.uid) {
     return res.status(400).json({ error: "User ID is required" });
   }
@@ -110,7 +110,7 @@ app.get("/api/recipes/:uid", verifyToken, async (req, res) => {
   }
 });
 
-app.post("/api/generate_recipe", verifyToken, async (req, res) => {
+app.post("/api/generate_recipe", async (req, res) => {
   const { uid, ingredients, minProtein, maxCarbs, maxFat, mealGroup } =
     req.body;
 


### PR DESCRIPTION
This pull request includes changes to the `server/server.js` file to remove the `verifyToken` middleware from certain API endpoints.

Security adjustments:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L82-R82): Removed the `verifyToken` middleware from the `GET /api/recipes/:uid` endpoint.
* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L113-R113): Removed the `verifyToken` middleware from the `POST /api/generate_recipe` endpoint.