### PR TITLE
SCRUM-54 Add Vercel configuration for URL rewrites to serve index.html

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes a configuration change to the `client/vercel.json` file to set up URL rewrites.

Configuration change:

* [`client/vercel.json`](diffhunk://#diff-855441862413f6eddef861a904efa430cedc3387cc88f6fb6157bed17a65b685R1-R8): Added a rewrite rule to redirect all paths to `index.html`.