### PR TITLE
SCRUM-58 Refactor MealCard and MealGroup components to use base64 image data instead of imageURL

### DIFF
--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -96,13 +96,13 @@ export default function Home() {
         <ul className="meals">
           {selectedDayMeals ? (
             selectedDayMeals.map(
-              ({ id, time, name, imageURL, protein, carbs, fat, done }) => (
+              ({ id, time, name, image, protein, carbs, fat, done }) => (
                 <MealCard
                   key={id}
                   id={id}
                   time={time}
                   name={name}
-                  imageURL={imageURL}
+                  image={image}
                   protein={protein}
                   carbs={carbs}
                   fat={fat}

--- a/client/src/components/MealCard.jsx
+++ b/client/src/components/MealCard.jsx
@@ -4,7 +4,7 @@ export default function MealCard({
   id,
   time,
   name,
-  imageURL,
+  image,
   protein,
   carbs,
   fat,
@@ -13,7 +13,7 @@ export default function MealCard({
 }) {
   const backgroundStyle = {
     background: `linear-gradient(rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 50%), linear-gradient(45deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 50%),
-        url(${imageURL})`,
+        url(data:image/png;base64,${image})`,
     backgroundPosition: "center",
     backgroundRepeat: "no-repeat",
     backgroundSize: "cover",

--- a/client/src/components/MealGroup.jsx
+++ b/client/src/components/MealGroup.jsx
@@ -18,9 +18,12 @@ export default function MealGroup({ title, recipes, onCreateNew }) {
         </div>
         <ul>
           {recipes.length > 0 &&
-            recipes.map((recipe) => (
-              <li className="picker__item" key={recipe.id}>
-                <img src={recipe.imageURL} alt={recipe.title} />
+            recipes.map((recipe, idx) => (
+              <li className="picker__item" key={idx}>
+                <img
+                  src={`data:image/png;base64,${recipe.image}`}
+                  alt={recipe.title}
+                />
                 <p className="body-s">{recipe.title}</p>
               </li>
             ))}


### PR DESCRIPTION
This pull request includes several changes to the `client/src` files to update how image data is handled. The most important changes are related to replacing the `imageURL` property with the `image` property and updating the way images are rendered.

Changes to image handling:

* [`client/src/Home.jsx`](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33L99-R105): Updated the `MealCard` component to use the `image` property instead of `imageURL`.
* [`client/src/components/MealCard.jsx`](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL7-R7): Replaced the `imageURL` property with `image` and updated the `backgroundStyle` to use a base64 encoded image URL. [[1]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL7-R7) [[2]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL16-R16)
* [`client/src/components/MealGroup.jsx`](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL21-R26): Modified the `recipes.map` function to use `idx` as the key and updated the `img` element to use a base64 encoded image URL.

Images:
<img width="1395" alt="Screenshot 2025-03-06 at 5 29 13 PM" src="https://github.com/user-attachments/assets/b549b758-0f93-4d0b-8713-6a64b1d8779f" />

<img width="1397" alt="Screenshot 2025-03-06 at 5 29 22 PM" src="https://github.com/user-attachments/assets/5515bc98-33d3-407d-beb1-4080117b7c0d" />
