### PR TITLE
SCRUM-63 Reduce left margin in content and meal plan generator styles

### DIFF
--- a/client/src/Home.css
+++ b/client/src/Home.css
@@ -1,6 +1,6 @@
 /* Content container */
 .content {
-    margin-left: 325px;
+    margin-left: 280px;
     padding: 48px;
     display: flex;
     flex-direction: column;

--- a/client/src/MealPlanGenerator.css
+++ b/client/src/MealPlanGenerator.css
@@ -1,5 +1,5 @@
 .generate-page {
-    margin-left: 325px;
+    margin-left: 280px;
     padding: 48px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This pull request includes changes to the CSS files to adjust the layout margins for better alignment and consistency.

Layout adjustments:

* [`client/src/Home.css`](diffhunk://#diff-3b1a9da07623e6c614d6f215bddee90c945a731e686938b8b0009b5523e3bf9dL3-R3): Changed the `.content` class margin-left from 325px to 280px.
* [`client/src/MealPlanGenerator.css`](diffhunk://#diff-7a7b0565044d4b893d86a4818618f71aa2ac16545de9f13e57fce07814f9bb41L2-R2): Changed the `.generate-page` class margin-left from 325px to 280px.