### PR TITLE
SCRUM-75 Add loading state to meal plan generation button

### DIFF
--- a/client/src/MealPlanGenerator.jsx
+++ b/client/src/MealPlanGenerator.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { getAuth } from "firebase/auth";
+import page from "page";
 
 import Sidenav from "./components/Sidenav";
 import CreateRecipe from "./components/CreateRecipe";
@@ -8,7 +9,6 @@ import MealGroup from "./components/MealGroup";
 
 import { SERVER_URL } from "./constants";
 
-// import { recipes } from "./fakedata.json";
 import "./MealPlanGenerator.css";
 
 export default function MealPlanGenerator() {
@@ -23,6 +23,7 @@ export default function MealPlanGenerator() {
     dinner: [],
     snack: [],
   });
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     // Fetch initial recipes data from the server
@@ -123,6 +124,8 @@ export default function MealPlanGenerator() {
         }
       }
 
+      setLoading(true);
+
       fetch(`${SERVER_URL}/api/generate_meal_plan`, {
         method: "POST",
         headers: {
@@ -142,9 +145,13 @@ export default function MealPlanGenerator() {
           } else {
             console.log("Meal plan generated:", data);
             setErrorMessage(null);
+            page("/");
           }
         })
-        .catch((error) => console.error("Error generating meal plan:", error));
+        .catch((error) => console.error("Error generating meal plan:", error))
+        .finally(() => {
+          setLoading(false);
+        });
     } else {
       console.log("No user is signed in.");
     }
@@ -214,8 +221,14 @@ export default function MealPlanGenerator() {
             <p>{errorMessage}</p>
           </div>
         )}
-        <button className="btn" onClick={handleGenerateMealPlan}>
-          <p className="btn-text">Generate 🔀</p>
+        <button
+          className="btn"
+          onClick={handleGenerateMealPlan}
+          disabled={loading}
+        >
+          <p className="btn-text">
+            {loading ? "Generating..." : "Generate 🔀"}
+          </p>
         </button>
       </div>
       {isModalOpen && (


### PR DESCRIPTION
This pull request includes several updates to the `MealPlanGenerator` component to improve user experience by adding loading states and navigation. The most important changes include importing the `page` library for navigation, adding a loading state, and updating the button to reflect the loading state.

Enhancements to user experience:

* [`client/src/MealPlanGenerator.jsx`](diffhunk://#diff-7272077c0bff68b90c7458e87ee151d33b921ed523b60273bc4a7fb25ab2bb00R3): Imported the `page` library to handle navigation after generating a meal plan.
* [`client/src/MealPlanGenerator.jsx`](diffhunk://#diff-7272077c0bff68b90c7458e87ee151d33b921ed523b60273bc4a7fb25ab2bb00R26): Introduced a `loading` state to manage the loading indicator when generating a meal plan.
* [`client/src/MealPlanGenerator.jsx`](diffhunk://#diff-7272077c0bff68b90c7458e87ee151d33b921ed523b60273bc4a7fb25ab2bb00R127-R128): Added `setLoading(true)` before the fetch call to indicate the start of the loading process.
* [`client/src/MealPlanGenerator.jsx`](diffhunk://#diff-7272077c0bff68b90c7458e87ee151d33b921ed523b60273bc4a7fb25ab2bb00R148-R154): Used `page("/")` to navigate to the home page after successfully generating a meal plan.
* [`client/src/MealPlanGenerator.jsx`](diffhunk://#diff-7272077c0bff68b90c7458e87ee151d33b921ed523b60273bc4a7fb25ab2bb00L217-R231): Updated the "Generate" button to show a "Generating..." state and disable the button while loading.