### PR TITLE
SCRUM-77 Fix MealInfo component naming

### DIFF
--- a/client/src/MealInfo.jsx
+++ b/client/src/MealInfo.jsx
@@ -8,7 +8,7 @@ import { SERVER_URL } from "./constants";
 
 import "./MealInfo.css";
 
-export default function MealPlanGenerator({ id }) {
+export default function MealInfo({ id }) {
   const [meal, setMeal] = useState(null);
   const [loading, setLoading] = useState(true);
 


### PR DESCRIPTION
This pull request includes a change to the `client/src/MealInfo.jsx` file. The change involves renaming the default export function from `MealPlanGenerator` to `MealInfo`.

* [`client/src/MealInfo.jsx`](diffhunk://#diff-dd264326910cb8b5a6d80b7edcf1d011b569b5974af8da2ed13db83ee1df5fa6L11-R11): Renamed the default export function from `MealPlanGenerator` to `MealInfo`.