### PR TITLE
SCRUM-78 Add recipe ID to generated recipe response

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -433,6 +433,7 @@ app.post("/api/generate_recipe", verifyToken, async (req, res) => {
     // Save recipe to database
     try {
       const docRef = await db.collection("recipes").add(recipe);
+      recipe.id = docRef.id;
       console.log("Document written with ID: ", docRef.id);
     } catch (e) {
       console.error("Error adding document: ", e);


### PR DESCRIPTION
This pull request includes a small but important change to the `server/server.js` file. The change ensures that the newly created recipe document's ID is assigned to the `recipe` object after saving it to the database.

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R436): Added a line to assign the document ID to the `recipe` object after saving it to the database.