### PR TITLE
SCRUM-93 Add endpoint to delete a recipe by ID with authorization checks

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -432,7 +432,7 @@ app.post("/api/generate_recipe", verifyToken, async (req, res) => {
 });
 
 // Delete a specific recipe by document ID
-app.delete("/api/recipe/:id", verifyToken, async (req, res) => {
+app.delete("/api/recipes/:id", verifyToken, async (req, res) => {
   const recipeId = req.params.id;
 
   if (!recipeId) {

--- a/server/server.js
+++ b/server/server.js
@@ -431,6 +431,38 @@ app.post("/api/generate_recipe", verifyToken, async (req, res) => {
   }
 });
 
+// Delete a specific recipe by document ID
+app.delete("/api/recipe/:id", verifyToken, async (req, res) => {
+  const recipeId = req.params.id;
+
+  if (!recipeId) {
+    return res.status(400).json({ error: "Recipe ID is required" });
+  }
+
+  try {
+    const docRef = db.collection("recipes").doc(recipeId);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return res.status(404).json({ error: "Recipe not found" });
+    }
+
+    const recipe = doc.data();
+
+    // Verify that the uid from the token matches the uid in the recipe
+    if (req.user.uid !== recipe.uid) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
+    await docRef.delete();
+
+    res.status(200).json({ message: "Recipe deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting recipe: ", error);
+    res.status(500).json({ error: "Failed to delete recipe" });
+  }
+});
+
 const port = parseInt(process.env.PORT) || 8080;
 const server = app.listen(port, () =>
   console.log(`Server listening on port ${port}`)


### PR DESCRIPTION
This pull request introduces a new endpoint to delete a specific recipe by its document ID in the `server/server.js` file. The most important change is the addition of the `DELETE /api/recipe/:id` endpoint, which includes error handling and user verification.

New endpoint addition:

* [`server/server.js`](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938R434-R465): Added a new `DELETE /api/recipe/:id` endpoint to delete a specific recipe by its document ID. This includes checking for the existence of the recipe, verifying the user ID, and handling errors appropriately.