### PR TITLE
SCRUM-94 Rename groupMeal to mealGroup for consistency in meal data handling

### DIFF
--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -171,12 +171,12 @@ export default function Home() {
           <ul className="meals">
             {selectedDayMeals ? (
               [...selectedDayMeals]
-                .sort((a, b) => a.groupMeal - b.groupMeal)
-                .map(({ id, groupMeal, title, image, nutrition, done }) => (
+                .sort((a, b) => a.mealGroup - b.mealGroup)
+                .map(({ id, mealGroup, title, image, nutrition, done }) => (
                   <MealCard
                     key={id}
                     id={id}
-                    groupMeal={groupMeal}
+                    mealGroup={mealGroup}
                     title={title}
                     image={image}
                     nutrition={nutrition}

--- a/client/src/components/MealCard.jsx
+++ b/client/src/components/MealCard.jsx
@@ -4,7 +4,7 @@ import "./MealCard.css";
 
 export default function MealCard({
   id,
-  groupMeal,
+  mealGroup,
   title,
   image,
   nutrition,
@@ -47,7 +47,7 @@ export default function MealCard({
       >
         <div className="meal-header">
           <div className="meal-info">
-            <p className="body-s">{getMealLabel(groupMeal)}</p>
+            <p className="body-s">{getMealLabel(mealGroup)}</p>
             <p className="body-s">{title}</p>
           </div>
           <button


### PR DESCRIPTION
This pull request includes changes to the `client/src/Home.jsx` and `client/src/components/MealCard.jsx` files to rename the `groupMeal` property to `mealGroup`.

Renaming property for consistency:

* [`client/src/Home.jsx`](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33L174-R179): Changed `groupMeal` to `mealGroup` in the sorting function and `MealCard` component mapping.
* [`client/src/components/MealCard.jsx`](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL7-R7): Updated the `MealCard` component to use `mealGroup` instead of `groupMeal` in the property list and `getMealLabel` function call. [[1]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL7-R7) [[2]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfL50-R50)

Before | After
:----------------:|:---------------:
![screencapture-macromate-vercel-app-2025-03-19-14_59_45](https://github.com/user-attachments/assets/1d5ff94d-17d5-4d3e-80bf-6c97d5a3bb9f) | ![screencapture-localhost-5173-2025-03-19-14_59_52](https://github.com/user-attachments/assets/180a98b7-30ad-44cb-a594-ac30932867ea)
