### PR TITLE
SCRUM-103 Update axios dependency to version 1.8.4 in package-lock.json

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1154,9 +1154,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",


### PR DESCRIPTION
This pull request includes an update to the `axios` package in the `server/package-lock.json` file. The version has been upgraded from 1.7.9 to 1.8.4. 

* [`server/package-lock.json`](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053L1157-R1159): Updated `axios` version from 1.7.9 to 1.8.4 to ensure the latest features and security updates are included.