### PR TITLE
Add API endpoint to replace a recipe in a meal plan with validation checks

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -488,6 +488,65 @@ app.post("/api/generate_recipe", verifyToken, async (req, res) => {
   }
 });
 
+// Update a meal plan for a specific date
+app.post("/api/replace_recipe", verifyToken, async (req, res) => {
+  const { uid, date, currentMealId, newMealId } = req.body;
+
+  if (!uid || !date || !currentMealId || !newMealId) {
+    return res.status(400).json({ error: "All fields are required" });
+  }
+
+  if (req.user.uid !== uid) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
+  // Verify that the newMealId is not the same as the currentMealId
+  if (currentMealId === newMealId) {
+    return res.status(400).json({ error: "New meal ID cannot be the same" });
+  }
+
+  // Verify that the date is in YYYY-MM-DD format
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(date)) {
+    return res.status(400).json({ error: "Invalid date format" });
+  }
+
+  // Verify that the newMealId is valid
+  const docRef = db.collection("recipes").doc(newMealId);
+  const doc = await docRef.get();
+  if (!doc.exists) {
+    return res.status(404).json({ error: "New meal not found" });
+  }
+
+  try {
+    const userDocRef = db.collection("plans").doc(uid);
+    const userDoc = await userDocRef.get();
+    if (!userDoc.exists) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    const datesCollectionRef = userDocRef.collection("dates");
+    const dateDocRef = datesCollectionRef.doc(date);
+    const dateDoc = await dateDocRef.get();
+    if (!dateDoc.exists) {
+      return res.status(404).json({ error: "Meal plan not found" });
+    }
+    const mealPlan = dateDoc.data();
+    const meals = mealPlan.meals;
+    const mealIndex = meals.findIndex((meal) => meal.id === currentMealId);
+    if (mealIndex === -1) {
+      return res.status(404).json({ error: "Current meal not found" });
+    }
+    meals[mealIndex].id = newMealId;
+    meals[mealIndex].done = false;
+    await dateDocRef.set({ meals }, { merge: true });
+
+    res.status(200).json({ message: "Meal plan updated successfully" });
+  } catch (error) {
+    console.error("Error updating meal plan:", error);
+    res.status(500).json({ error: "Failed to update meal plan" });
+  }
+});
+
 // Delete a specific recipe by document ID
 app.delete("/api/recipes/:id", verifyToken, async (req, res) => {
   const recipeId = req.params.id;

--- a/server/server.js
+++ b/server/server.js
@@ -502,7 +502,9 @@ app.post("/api/replace_recipe", verifyToken, async (req, res) => {
 
   // Verify that the newMealId is not the same as the currentMealId
   if (currentMealId === newMealId) {
-    return res.status(400).json({ error: "New meal ID cannot be the same" });
+    return res
+      .status(400)
+      .json({ error: "New meal ID must differ from the current meal ID" });
   }
 
   // Verify that the date is in YYYY-MM-DD format
@@ -532,6 +534,11 @@ app.post("/api/replace_recipe", verifyToken, async (req, res) => {
     }
     const mealPlan = dateDoc.data();
     const meals = mealPlan.meals;
+
+    if (meals !== undefined && !Array.isArray(meals)) {
+      return res.status(400).json({ error: "Invalid meal plan format" });
+    }
+
     const mealIndex = meals.findIndex((meal) => meal.id === currentMealId);
     if (mealIndex === -1) {
       return res.status(404).json({ error: "Current meal not found" });

--- a/server/server.js
+++ b/server/server.js
@@ -535,7 +535,7 @@ app.post("/api/replace_recipe", verifyToken, async (req, res) => {
     const mealPlan = dateDoc.data();
     const meals = mealPlan.meals;
 
-    if (meals !== undefined && !Array.isArray(meals)) {
+    if (!meals || !Array.isArray(meals)) {
       return res.status(400).json({ error: "Invalid meal plan format" });
     }
 


### PR DESCRIPTION
This pull request introduces a new endpoint to the `server.js` file for replacing a meal in a user's meal plan. The endpoint includes several validation checks and error handling to ensure the integrity of the meal plan update process.

Key changes:

* Added a new POST endpoint `/api/replace_recipe` to replace a meal in a user's meal plan (`server/server.js`).
  * Validates required fields (`uid`, `date`, `currentMealId`, `newMealId`).
  * Ensures the new meal ID is different from the current meal ID.
  * Checks the date format to be `YYYY-MM-DD`.
  * Verifies the existence of the new meal ID in the `recipes` collection.
  * Updates the meal plan in the `plans` collection if all checks pass.

These changes enhance the functionality of the server by allowing users to update their meal plans with new recipes while ensuring data consistency and proper error handling.