### PR TITLE
SCRUM-121 Add inverted index for recipe ingredient matching

### DIFF
--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -206,18 +206,18 @@ export default function Home() {
   }, [recipes]);
 
   const buildInvertedIndex = (recipes) => {
-    const index = {};
+    const ingredientIndex = {};
 
     recipes.forEach((recipe) => {
       recipe.ingredients.forEach((ingredient) => {
-        if (!index[ingredient]) {
-          index[ingredient] = [];
+        if (!ingredientIndex[ingredient]) {
+          ingredientIndex[ingredient] = [];
         }
-        index[ingredient].push(recipe.id);
+        ingredientIndex[ingredient].push(recipe.id);
       });
     });
 
-    return index;
+    return ingredientIndex;
   };
 
   return (

--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -31,6 +31,7 @@ export default function Home() {
   const [userData, setUserData] = useState({});
   const [selectedDayMeals, setSelectedDayMeals] = useState(null);
   const [selectedDayProgress, setSelectedDayProgress] = useState(null);
+  const [invertedIndex, setInvertedIndex] = useState({});
   const [loading, setLoading] = useState(true);
 
   const getFormattedDate = (date) => date.toISOString().split("T")[0];
@@ -197,6 +198,28 @@ export default function Home() {
     }
   }, [selectedDay, mealPlans, recipes]);
 
+  useEffect(() => {
+    if (recipes.length > 0) {
+      const index = buildInvertedIndex(recipes);
+      setInvertedIndex(index); // Save the index in state
+    }
+  }, [recipes]);
+
+  const buildInvertedIndex = (recipes) => {
+    const index = {};
+
+    recipes.forEach((recipe) => {
+      recipe.ingredients.forEach((ingredient) => {
+        if (!index[ingredient]) {
+          index[ingredient] = [];
+        }
+        index[ingredient].push(recipe.id);
+      });
+    });
+
+    return index;
+  };
+
   return (
     <>
       <div className="content">
@@ -236,6 +259,7 @@ export default function Home() {
                     allRecipes={recipes}
                     applicationContext="home"
                     onReplaceRecipeId={updateRecipeId}
+                    invertedIndex={invertedIndex}
                   />
                 ))
             ) : (

--- a/client/src/Home.jsx
+++ b/client/src/Home.jsx
@@ -201,7 +201,7 @@ export default function Home() {
   useEffect(() => {
     if (recipes.length > 0) {
       const index = buildInvertedIndex(recipes);
-      setInvertedIndex(index); // Save the index in state
+      setInvertedIndex(index);
     }
   }, [recipes]);
 

--- a/client/src/components/MealCard.jsx
+++ b/client/src/components/MealCard.jsx
@@ -20,6 +20,7 @@ export default function MealCard({
   onDeleteRecipe,
   allRecipes,
   onReplaceRecipeId,
+  invertedIndex,
 }) {
   const [deleteIcon, setDeleteIcon] = useState("../icons/trash-filled.svg");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -154,6 +155,7 @@ export default function MealCard({
           onClose={handleCloseModal}
           onReplace={handleReplaceRecipe}
           currentRecipeId={id}
+          invertedIndex={invertedIndex}
         />
       )}
     </>

--- a/client/src/components/ReplaceRecipeModal.jsx
+++ b/client/src/components/ReplaceRecipeModal.jsx
@@ -12,6 +12,28 @@ export default function ReplaceRecipeModal({
     (recipe) => recipe.id === currentRecipeId
   );
 
+  // If no matching recipe is found, display a fallback message
+  if (!currentRecipe) {
+    return (
+      <div
+        className="modal-overlay"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        <div className="modal-content">
+          <h4>Replace Recipe</h4>
+          <p className="no-recipes-message body-s">
+            The current recipe could not be found.
+          </p>
+          <div className="modal-footer">
+            <button className="btn btn-close" onClick={onClose}>
+              <span className="btn-text">Close</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const similarRecipes = findSimilarRecipes(
     currentRecipe,
     invertedIndex,

--- a/client/src/components/ReplaceRecipeModal.jsx
+++ b/client/src/components/ReplaceRecipeModal.jsx
@@ -99,7 +99,7 @@ const findSimilarRecipes = (currentRecipe, invertedIndex, allRecipes) => {
     .map(([recipeId]) => recipeId);
 
   // Return the full recipe objects for the sorted IDs
-  return sortedRecipeIds.map((id) =>
-    allRecipes.find((recipe) => recipe.id === id)
-  );
+  return sortedRecipeIds
+    .map((id) => allRecipes.find((recipe) => recipe.id === id))
+    .filter((recipe) => recipe !== undefined);
 };

--- a/client/src/components/ReplaceRecipeModal.jsx
+++ b/client/src/components/ReplaceRecipeModal.jsx
@@ -6,9 +6,16 @@ export default function ReplaceRecipeModal({
   currentRecipeId,
   onClose,
   onReplace,
+  invertedIndex,
 }) {
-  const filteredRecipes = allRecipes.filter(
-    (recipe) => recipe.mealGroup === mealGroup && recipe.id !== currentRecipeId
+  const currentRecipe = allRecipes.find(
+    (recipe) => recipe.id === currentRecipeId
+  );
+
+  const similarRecipes = findSimilarRecipes(
+    currentRecipe,
+    invertedIndex,
+    allRecipes
   );
 
   return (
@@ -18,21 +25,25 @@ export default function ReplaceRecipeModal({
     >
       <div className="modal-content">
         <h4>Replace Recipe</h4>
-        <ul className="recipe-list">
-          {filteredRecipes.map((recipe) => (
-            <li
-              key={recipe.id}
-              className="recipe-item"
-              onClick={() => onReplace(recipe.id)}
-            >
-              <img
-                src={recipe.image || "/images/placeholder.webp"}
-                alt={recipe.title}
-              />
-              <p className="body-s">{recipe.title}</p>
-            </li>
-          ))}
-        </ul>
+        {similarRecipes.length > 0 ? (
+          <ul className="recipe-list">
+            {similarRecipes.map((recipe) => (
+              <li
+                key={recipe.id}
+                className="recipe-item"
+                onClick={() => onReplace(recipe.id)}
+              >
+                <img
+                  src={recipe.image || "/images/placeholder.webp"}
+                  alt={recipe.title}
+                />
+                <p className="body-s">{recipe.title}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="no-recipes-message body-s">No similar recipes found.</p>
+        )}
         <div className="modal-footer">
           <button className="btn btn-close" onClick={onClose}>
             <span className="btn-text">Close</span>
@@ -42,3 +53,31 @@ export default function ReplaceRecipeModal({
     </div>
   );
 }
+
+// Helper function to find similar recipes
+const findSimilarRecipes = (currentRecipe, invertedIndex, allRecipes) => {
+  const ingredientMatches = new Map();
+
+  currentRecipe.ingredients.forEach((ingredient) => {
+    if (invertedIndex[ingredient]) {
+      invertedIndex[ingredient].forEach((recipeId) => {
+        if (recipeId !== currentRecipe.id) {
+          ingredientMatches.set(
+            recipeId,
+            (ingredientMatches.get(recipeId) || 0) + 1
+          );
+        }
+      });
+    }
+  });
+
+  // Sort recipes by the number of matching ingredients (descending)
+  const sortedRecipeIds = [...ingredientMatches.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([recipeId]) => recipeId);
+
+  // Return the full recipe objects for the sorted IDs
+  return sortedRecipeIds.map((id) =>
+    allRecipes.find((recipe) => recipe.id === id)
+  );
+};

--- a/client/src/components/ReplaceRecipeModal.jsx
+++ b/client/src/components/ReplaceRecipeModal.jsx
@@ -1,3 +1,5 @@
+import { findSimilarRecipes } from "../utils/recipeUtils";
+
 import "./ReplaceRecipeModal.css";
 
 export default function ReplaceRecipeModal({
@@ -75,31 +77,3 @@ export default function ReplaceRecipeModal({
     </div>
   );
 }
-
-// Helper function to find similar recipes
-const findSimilarRecipes = (currentRecipe, invertedIndex, allRecipes) => {
-  const ingredientMatches = new Map();
-
-  currentRecipe.ingredients.forEach((ingredient) => {
-    if (invertedIndex[ingredient]) {
-      invertedIndex[ingredient].forEach((recipeId) => {
-        if (recipeId !== currentRecipe.id) {
-          ingredientMatches.set(
-            recipeId,
-            (ingredientMatches.get(recipeId) || 0) + 1
-          );
-        }
-      });
-    }
-  });
-
-  // Sort recipes by the number of matching ingredients (descending)
-  const sortedRecipeIds = [...ingredientMatches.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([recipeId]) => recipeId);
-
-  // Return the full recipe objects for the sorted IDs
-  return sortedRecipeIds
-    .map((id) => allRecipes.find((recipe) => recipe.id === id))
-    .filter((recipe) => recipe !== undefined);
-};

--- a/client/src/utils/recipeUtils.js
+++ b/client/src/utils/recipeUtils.js
@@ -1,0 +1,31 @@
+// Helper function to find similar recipes
+export const findSimilarRecipes = (
+  currentRecipe,
+  invertedIndex,
+  allRecipes
+) => {
+  const ingredientMatches = new Map();
+
+  currentRecipe.ingredients.forEach((ingredient) => {
+    if (invertedIndex[ingredient]) {
+      invertedIndex[ingredient].forEach((recipeId) => {
+        if (recipeId !== currentRecipe.id) {
+          ingredientMatches.set(
+            recipeId,
+            (ingredientMatches.get(recipeId) || 0) + 1
+          );
+        }
+      });
+    }
+  });
+
+  // Sort recipes by the number of matching ingredients (descending)
+  const sortedRecipeIds = [...ingredientMatches.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([recipeId]) => recipeId);
+
+  // Return the full recipe objects for the sorted IDs
+  return sortedRecipeIds
+    .map((id) => allRecipes.find((recipe) => recipe.id === id))
+    .filter((recipe) => recipe !== undefined);
+};


### PR DESCRIPTION
This pull request introduces a new feature to enhance the recipe replacement functionality by adding an inverted index for efficient recipe search based on ingredients. The most important changes include the addition of the inverted index state, the implementation of the `buildInvertedIndex` function, and the use of this index in the `ReplaceRecipeModal` component to find similar recipes.

### Enhancements to recipe replacement functionality:

* [`client/src/Home.jsx`](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33R34): Added state `invertedIndex` and implemented `buildInvertedIndex` function to create an index of ingredients to recipe IDs. The index is updated whenever the `recipes` state changes. [[1]](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33R34) [[2]](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33R201-R222)
* [`client/src/Home.jsx`](diffhunk://#diff-16c5178313a2084c1cc41398cb29a48b21ffe152dfd3726edc3e637e2cd9fc33R262): Passed the `invertedIndex` state to `MealCard` components.
* [`client/src/components/MealCard.jsx`](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfR23): Added `invertedIndex` prop to `MealCard` component and passed it to `ReplaceRecipeModal`. [[1]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfR23) [[2]](diffhunk://#diff-1709d557f9c27c9f122e851a87a1f4d7aeeb303243f5dec81d66adce1aae3bdfR158)
* [`client/src/components/ReplaceRecipeModal.jsx`](diffhunk://#diff-f6dd4e38cc7434f86d95847190a5d66a0cc0f9aa95a9bb823ea807a6cf5ad2b6R9-R18): Modified to use `invertedIndex` for finding similar recipes and display them in the modal. Implemented `findSimilarRecipes` helper function to find and sort recipes based on matching ingredients. [[1]](diffhunk://#diff-f6dd4e38cc7434f86d95847190a5d66a0cc0f9aa95a9bb823ea807a6cf5ad2b6R9-R18) [[2]](diffhunk://#diff-f6dd4e38cc7434f86d95847190a5d66a0cc0f9aa95a9bb823ea807a6cf5ad2b6R28-R30) [[3]](diffhunk://#diff-f6dd4e38cc7434f86d95847190a5d66a0cc0f9aa95a9bb823ea807a6cf5ad2b6R44-R46) [[4]](diffhunk://#diff-f6dd4e38cc7434f86d95847190a5d66a0cc0f9aa95a9bb823ea807a6cf5ad2b6R56-R83)