### PR TITLE
SCRUM-133 Refactor MealGroup and RecipeGrid components to simplify recipe rendering and remove unused props

### DIFF
--- a/client/src/components/MealGroup.jsx
+++ b/client/src/components/MealGroup.jsx
@@ -8,21 +8,18 @@ export default function MealGroup({
   onCreateNew,
   onSelectRecipe,
   selectedRecipes,
-  applicationContext,
 }) {
   return (
     <div className="meal-group">
       <h6>{title}</h6>
 
       <div className="picker">
-        {applicationContext !== "recipes" && (
-          <div className="create-new-btn" onClick={onCreateNew}>
-            <div>
-              <CircledPlusIcon size={80} />
-            </div>
-            <p className="body-s">+ Create New</p>
+        <div className="create-new-btn" onClick={onCreateNew}>
+          <div>
+            <CircledPlusIcon size={80} />
           </div>
-        )}
+          <p className="body-s">+ Create New</p>
+        </div>
         <ul>
           {recipes.length > 0 ? (
             recipes.map((recipe) => (

--- a/client/src/components/MealGroup.jsx
+++ b/client/src/components/MealGroup.jsx
@@ -1,4 +1,3 @@
-import MealCard from "./MealCard";
 import "./MealGroup.css";
 import CircledPlusIcon from "../icons/CircledPlusIcon";
 
@@ -10,7 +9,6 @@ export default function MealGroup({
   onSelectRecipe,
   selectedRecipes,
   applicationContext,
-  onDeleteRecipe,
 }) {
   return (
     <div className="meal-group">
@@ -27,45 +25,30 @@ export default function MealGroup({
         )}
         <ul>
           {recipes.length > 0 ? (
-            recipes.map((recipe) =>
-              applicationContext === "recipes" ? (
-                <MealCard
-                  key={`${mealGroup}-${recipe.id}`}
-                  id={recipe.id}
-                  mealGroup={recipe.mealGroup}
-                  title={recipe.title}
-                  image={recipe.image}
-                  nutrition={recipe.nutrition}
-                  done={recipe.done}
-                  onMealDone={onSelectRecipe}
-                  applicationContext={applicationContext}
-                  onDeleteRecipe={onDeleteRecipe}
+            recipes.map((recipe) => (
+              <li className="picker__item" key={`${mealGroup}-${recipe.id}`}>
+                <input
+                  type="checkbox"
+                  className="hidden-checkbox"
+                  id={`recipe-${mealGroup}-${recipe.id}`}
+                  checked={selectedRecipes.includes(recipe.id)}
+                  onChange={(e) =>
+                    onSelectRecipe(mealGroup, recipe.id, e.target.checked)
+                  }
                 />
-              ) : (
-                <li className="picker__item" key={`${mealGroup}-${recipe.id}`}>
-                  <input
-                    type="checkbox"
-                    className="hidden-checkbox"
-                    id={`recipe-${mealGroup}-${recipe.id}`}
-                    checked={selectedRecipes.includes(recipe.id)}
-                    onChange={(e) =>
-                      onSelectRecipe(mealGroup, recipe.id, e.target.checked)
-                    }
+                <label
+                  className="recipe-label"
+                  htmlFor={`recipe-${mealGroup}-${recipe.id}`}
+                >
+                  <img
+                    src={recipe?.image ?? "/images/placeholder.webp"}
+                    alt={recipe.title}
+                    loading="lazy"
                   />
-                  <label
-                    className="recipe-label"
-                    htmlFor={`recipe-${mealGroup}-${recipe.id}`}
-                  >
-                    <img
-                      src={recipe?.image ?? "/images/placeholder.webp"}
-                      alt={recipe.title}
-                      loading="lazy"
-                    />
-                    <p className="body-s">{recipe.title}</p>
-                  </label>
-                </li>
-              )
-            )
+                  <p className="body-s">{recipe.title}</p>
+                </label>
+              </li>
+            ))
           ) : (
             <p className="body-m">No recipes found</p>
           )}

--- a/client/src/components/RecipeGrid.jsx
+++ b/client/src/components/RecipeGrid.jsx
@@ -10,11 +10,7 @@ export default function RecipeGrid({ recipes, onDeleteRecipe }) {
             <MealCard
               key={recipe.id}
               id={recipe.id}
-              mealGroup={recipe.mealGroup}
-              title={recipe.title}
-              image={recipe.image}
-              nutrition={recipe.nutrition}
-              done={recipe.done}
+              meal={recipe}
               applicationContext="recipes"
               onDeleteRecipe={onDeleteRecipe}
             />


### PR DESCRIPTION
This pull request includes changes to the `MealGroup` and `RecipeGrid` components to simplify the code and improve maintainability. The most important changes include removing the `MealCard` import and refactoring how recipes are displayed in the `MealGroup` component, as well as modifying the `RecipeGrid` component to pass the entire `recipe` object to `MealCard`.

Code simplification and refactoring:

* [`client/src/components/MealGroup.jsx`](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL1): Removed the `MealCard` import since it is no longer used.
* [`client/src/components/MealGroup.jsx`](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL13): Removed the `onDeleteRecipe` prop from the `MealGroup` component as it is no longer needed.
* [`client/src/components/MealGroup.jsx`](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL30-R28): Refactored the recipe mapping logic to remove the `MealCard` component and directly render the recipe information within a list item. [[1]](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL30-R28) [[2]](diffhunk://#diff-4361ac94da04fb7f0f479b4c925a1a7b35e9e7455201eff0d314bd00c6553c1aL67-R51)
* [`client/src/components/RecipeGrid.jsx`](diffhunk://#diff-441dbe7f1bf3c5a06c93df5885d4fa260da5a86210640cb68d625a832e493702L13-R13): Modified the `RecipeGrid` component to pass the entire `recipe` object to the `MealCard` component instead of individual properties.