### PR TITLE
SCRUM-144 Refactor generate_recipe endpoint to remove mealGroup requirement and simplify validation

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -382,17 +382,9 @@ app.post("/api/generate_meal_plan", verifyToken, async (req, res) => {
 });
 
 app.post("/api/generate_recipe", verifyToken, async (req, res) => {
-  const { uid, ingredients, minProtein, maxCarbs, maxFat, mealGroup } =
-    req.body;
+  const { uid, ingredients, minProtein, maxCarbs, maxFat } = req.body;
 
-  if (
-    !uid ||
-    !ingredients ||
-    !minProtein ||
-    !maxCarbs ||
-    !maxFat ||
-    !mealGroup
-  ) {
+  if (!uid || !ingredients || !minProtein || !maxCarbs || !maxFat) {
     return res.status(400).json({ error: "All fields are required" });
   }
 
@@ -432,7 +424,6 @@ app.post("/api/generate_recipe", verifyToken, async (req, res) => {
       recipe = parsedRecipe;
     }
 
-    recipe.mealGroup = mealGroup;
     recipe.uid = uid;
     recipe.image = null;
 


### PR DESCRIPTION
This pull request simplifies the `generate_recipe` API endpoint by removing the `mealGroup` parameter, which is no longer required for recipe generation. The changes include updates to the request body validation and the recipe object construction.

### Changes to `generate_recipe` API:

* Removed the `mealGroup` parameter from the request body and updated the validation logic to no longer check for its presence. (`server/server.js`, [server/server.jsL385-R387](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L385-R387))
* Eliminated the assignment of the `mealGroup` property to the `recipe` object, as it is no longer part of the API's functionality. (`server/server.js`, [server/server.jsL435](diffhunk://#diff-8cf1ffe3788af127768748703e2f15dcfb3a05ffd20b4c2375223637e3260938L435))