### PR TITLE
SCRUM-145 Remove mealGroup prop and associated form elements from CreateRecipe component

### DIFF
--- a/client/src/components/CreateRecipe.jsx
+++ b/client/src/components/CreateRecipe.jsx
@@ -16,7 +16,7 @@ const allIngredients = [
   "Smoothie", "Protein Bar", "Boiled Eggs", "Cottage Cheese", "Seeds", "Greek Yogurt"
 ];
 
-const CreateRecipe = ({ onClose, mealGroup, onAddRecipe }) => {
+const CreateRecipe = ({ onClose, onAddRecipe }) => {
   const [loading, setLoading] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIngredients, setSelectedIngredients] = useState([]);
@@ -51,9 +51,6 @@ const CreateRecipe = ({ onClose, mealGroup, onAddRecipe }) => {
       const idToken = await user.getIdToken();
       const uid = user.uid;
 
-      const selectedMealGroup = parseInt(
-        document.getElementById("meal-group").value
-      );
       const minProtein = parseInt(document.getElementById("min-protein").value);
       const maxCarbs = parseInt(document.getElementById("max-carbs").value);
       const maxFat = parseInt(document.getElementById("max-fat").value);
@@ -85,7 +82,6 @@ const CreateRecipe = ({ onClose, mealGroup, onAddRecipe }) => {
             minProtein,
             maxCarbs,
             maxFat,
-            mealGroup: selectedMealGroup,
           }),
         });
 
@@ -137,23 +133,6 @@ const CreateRecipe = ({ onClose, mealGroup, onAddRecipe }) => {
       <div className="modal-content">
         <h6>Create New Recipe</h6>
         <form>
-          <div className="form-group">
-            <label htmlFor="meal-group" className="body-s">
-              Meal Group
-            </label>
-            <select
-              id="meal-group"
-              name="meal-group"
-              defaultValue={mealGroup}
-              required
-              className="body-s"
-            >
-              <option value="1">Breakfast</option>
-              <option value="2">Lunch</option>
-              <option value="3">Dinner</option>
-              <option value="4">Snack</option>
-            </select>
-          </div>
           <div className="form-group">
             <label htmlFor="ingredient-search" className="body-s">
               Ingredients


### PR DESCRIPTION
This pull request simplifies the `CreateRecipe` component in `client/src/components/CreateRecipe.jsx` by removing the `mealGroup` prop and all related functionality. The changes streamline the component's code and reduce unnecessary form fields.

### Removal of `mealGroup` functionality:

* Removed the `mealGroup` prop from the `CreateRecipe` component's props. (`[client/src/components/CreateRecipe.jsxL19-R19](diffhunk://#diff-f28e439c1e9a1d50f388925191b090686a1a9486e391e179011a4f181c16d901L19-R19)`)
* Eliminated the logic for retrieving and parsing the `mealGroup` value from the DOM. (`[client/src/components/CreateRecipe.jsxL54-L56](diffhunk://#diff-f28e439c1e9a1d50f388925191b090686a1a9486e391e179011a4f181c16d901L54-L56)`)
* Removed the `mealGroup` field from the payload sent in the POST request. (`[client/src/components/CreateRecipe.jsxL88](diffhunk://#diff-f28e439c1e9a1d50f388925191b090686a1a9486e391e179011a4f181c16d901L88)`)
* Deleted the "Meal Group" form field, including its label, dropdown, and associated options. (`[client/src/components/CreateRecipe.jsxL140-L156](diffhunk://#diff-f28e439c1e9a1d50f388925191b090686a1a9486e391e179011a4f181c16d901L140-L156)`)