### PR TITLE
SCRUM-147 Remove Settings tab from the sidebar

### DIFF
--- a/client/src/components/Sidenav.jsx
+++ b/client/src/components/Sidenav.jsx
@@ -6,7 +6,6 @@ import useTheme from "../hooks/useTheme";
 import "./Sidenav.css";
 import HomeIcon from "../icons/HomeIcon";
 import UserIcon from "../icons/UserIcon";
-import SettingIcon from "../icons/SettingIcon";
 import MoonIcon from "../icons/MoonIcon";
 import SidebarIcon from "../icons/SidebarIcon";
 import ChefHatIcon from "../icons/ChefHatIcon";
@@ -78,17 +77,14 @@ export default function Sidenav({ onToggleTheme }) {
               <CalendarIcon color="var(--icon-color)" />
               <p className="body-m">Generate Plan</p>
             </a>
-            <a href="/profile" 
+            <a
+              href="/profile"
               className={`nav-item ${
                 currentPath === "/profile" ? "active" : ""
               }`}
->
+            >
               <UserIcon color="var(--icon-color)" />
               <p className="body-m">Profile</p>
-            </a>
-            <a href="/" className="nav-item">
-              <SettingIcon color="var(--icon-color)" />
-              <p className="body-m">Settings</p>
             </a>
           </div>
         </div>


### PR DESCRIPTION
This pull request makes changes to the `Sidenav.jsx` file to remove the unused `SettingIcon` import and the corresponding "Settings" navigation item from the sidebar. It also includes minor formatting adjustments to improve code readability.

### Removal of "Settings" functionality:

* [`client/src/components/Sidenav.jsx`](diffhunk://#diff-cf4686b80d69f6d3f89d133171d85a3e759ebb3752804f8aa21e7f4ab438e577L9): Removed the import for `SettingIcon` as it is no longer used in the component.
* [`client/src/components/Sidenav.jsx`](diffhunk://#diff-cf4686b80d69f6d3f89d133171d85a3e759ebb3752804f8aa21e7f4ab438e577L81-L92): Removed the "Settings" navigation item from the sidebar, including its associated icon and label.

### Code readability improvements:

* [`client/src/components/Sidenav.jsx`](diffhunk://#diff-cf4686b80d69f6d3f89d133171d85a3e759ebb3752804f8aa21e7f4ab438e577L81-L92): Reformatted the "Profile" navigation item's JSX to improve readability by splitting attributes across multiple lines.